### PR TITLE
Updated frontend HTTP port for latest container version

### DIFF
--- a/bankong/docker/docker-compose-bankong-combined_local_portchange.yaml
+++ b/bankong/docker/docker-compose-bankong-combined_local_portchange.yaml
@@ -16,7 +16,7 @@ services:
    hostname: frontend.bankong
    restart: on-failure
    ports:
-    - 29080:80
+    - 29080:8080
   bankong-backend-transactions:
    networks:
    - kong-edu-net


### PR DESCRIPTION
As discussed with John, this fix should allow for frontend container to operate correctly for new users utilising the "latest" tag of the containers, may be worth updating other compose files using this same port for Frontend container also